### PR TITLE
upload dev builds with prerelease label

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ install:
 script:
   - conda build ./recipe
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main
+  - upload_or_check_non_existence ./recipe conda-forge --channel=prerelease

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Feedstock license: BSD 3-Clause
 
 Summary: FEniCS is a collection of free software for automated, efficient solution of differential equations
 
+FEniCS is a collection of free software for automated, efficient solution of differential equations
+(<http://fenicsproject.org>). It provides C++ and Python interfaces, and creates effecient solvers via
+expression of finite variational statements in a domain-specific language that are transformed and
+just-in-time compiled into efficient implementations.
 
 
 Installing fenics

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -54,17 +54,17 @@ yum install -y wget
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=prerelease || exit 1
 
     set -x
     export CONDA_PY=34
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=prerelease || exit 1
 
     set -x
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=prerelease || exit 1
 EOF

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,6 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
+channels:
+  targets:
+    - [conda-forge, prerelease]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - ply
     - six
     - sympy
-    - subprocess32  # [not py3k]
+    - subprocess32  # [py2k]
 
   run:
     - python
@@ -42,7 +42,7 @@ requirements:
     - numpy
     - six
     - sympy
-    - subprocess32 # [not py3k]
+    - subprocess32  # [py2k]
 
 test:
 


### PR DESCRIPTION
intead of main, which means that `conda install fenics` now gets 2016.2.dev.

We need to figure out how to pull or relable the existing 2016.2.dev packages that have been erroneously upload to the main channel (cc @jakirkham).

related: https://github.com/conda-forge/conda-forge.github.io/issues/147

This follows Python 3.6-pre, which is using this prerelease label.