### PR TITLE
scrub unused dependencies in cmake files

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,3 +39,15 @@ cmake .. \
 
 make VERBOSE=1 -j${CPU_COUNT}
 make install
+
+# remove paths for unused deps in cmake files
+# these paths may not exist on targets and aren't needed,
+# but cmake will die with 'no rule to make /Applications/...libclang_rt.osx.a'
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    find $PREFIX/share/dolfin -name '*.cmake' -print -exec sh -c "sed -E -i ''  's@/Applications/Xcode.app[^;]*(.dylib|.framework|.a);@@g' {}" \;
+else
+    find $PREFIX/share/dolfin -name '*.cmake' -print -exec sh -c "sed -E -i''  's@/usr/lib(64)?/[^;]*(.so|.a);@@g' {}" \;
+fi
+
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - clang6-explicit-in-copy.patch  # [osx]
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
which cause portability problems for dolfin because libraries that aren't going to be used are checked-for before building.

Specifically, there are references to the  clang runtime and SDK used to build dolfin on macOS, which are not used in the resulting dolfin JIT builds.

I'm not sure why CMake does this, or if there's a fix to be made in dolfin to exclude them, but this appears to work.