### PR TITLE
remove demos from installed package

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -42,6 +42,9 @@ cmake .. \
 make VERBOSE=1 -j${CPU_COUNT}
 make install
 
+# Don't include demos in installed package
+rm -rf $PREFIX/share/dolfin/demo
+
 # remove paths for unused deps in cmake files
 # these paths may not exist on targets and aren't needed,
 # but cmake will die with 'no rule to make /Applications/...libclang_rt.osx.a'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bb2731d58ec6f56db2f354141f4a2bb6c20b67ae99407a1854f09fd919b9e1d2
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
They are 50% of the install size (20/40MB), and can be retrieved from the website, etc.

@garth-wells, @mikaem: is this okay to do?