### PR TITLE
setuptools is a runtime requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: ba793a2d41995d65ce4ee9e955e06342a6357174420b727cfde9fc6c70590e92
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -40,6 +40,7 @@ requirements:
 
   run:
     - python
+    - setuptools
     - boost 1.63.*
     - cmake
     - eigen


### PR DESCRIPTION
since packages such as ufl get `__version__` via pkg_resources

This wasn't caught by tests because test dependencies nose/pytest themselves happen to directly depend on setuptools

This should fix the build in https://github.com/conda-forge/mshr-feedstock/pull/7

This also wouldn't show up for local users because conda's default behavior is for the Python package to artificially depend on pip/setuptools. conda-forge builds run in a conservative mode that disables this, requiring setuptools/pip dependencies be made explicit.