### PR TITLE
include mpmath which is necessary for sympy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,7 @@ requirements:
     - six
     - subprocess32  # [py2k]
     - sympy
+    - mpmath
     - hdf5 1.8.18
 
 test:


### PR DESCRIPTION
if mpmath is not installed then import fenics fails

I hope I did add it in the right place. Thanks!