### PR TITLE
2017.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/component-requirements.txt
+++ b/recipe/component-requirements.txt
@@ -1,6 +1,6 @@
 # fenics-components requirements.txt
-https://bitbucket.org/fenics-project/dijitso/downloads/dijitso-2017.1.0.tar.gz --hash=sha256:ef23952539d349fbd384d41302abc94413d485ca7e8c29e8a0debc2aadaf8657
-https://bitbucket.org/fenics-project/ufl/downloads/ufl-2017.1.0.tar.gz --hash=sha256:af87fa10f492660e8dd9f5c820c03529e017b80bf2002da54b8234c56b8dda8f
-https://bitbucket.org/fenics-project/instant/downloads/instant-2017.1.0.tar.gz --hash=sha256:38f56bd9a583518fb023a90be6d09a114d74a36cacb91cbf50167002ac815ee7
-https://bitbucket.org/fenics-project/fiat/downloads/fiat-2017.1.0.tar.gz --hash=sha256:d4288401ad16c4598720f9db0810a522f7f0eadad35d8211bac7120bce5fde94
-https://bitbucket.org/fenics-project/ffc/downloads/ffc-2017.1.0.tar.gz --hash=sha256:2073c4d8f998798a3b0a8a371e74d9848f0e52933cf5f35cee21e82ab3fe87b3
+https://bitbucket.org/fenics-project/dijitso/downloads/dijitso-2017.2.0.tar.gz --hash=sha256:05a893d17f8a50067d303b232e41592dce2840d6499677ad8b457ba58a679b58
+https://bitbucket.org/fenics-project/ffc/downloads/ffc-2017.2.0.tar.gz --hash=sha256:c7e52c552bb6bf4748ba27d63725eb79ffba7260a6052a6e5f3c3e0e6b0a7279
+https://bitbucket.org/fenics-project/fiat/downloads/fiat-2017.2.0.tar.gz --hash=sha256:abf4bfae6ab67601ab49e6df1ee3664c19c36f18467720706ec9e62d4c75837c
+https://bitbucket.org/fenics-project/instant/downloads/instant-2017.2.0.tar.gz --hash=sha256:be24f162fd1a89b82fae002db8df0b4f111fd50db83d78c0c121015c02e45b7b
+https://bitbucket.org/fenics-project/ufl/downloads/ufl-2017.2.0.tar.gz --hash=sha256:45562fcd29ceb2f2e37c44bc2552b8e6c5d76409f73526096d2bcdb7078cf99c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2017.1.0" %}
 {% set petsc_version = '3.7.*' %}
+{% set version = "2017.2.0" %}
 {% set swig_version = '3.0.12' %}
 
 package:
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-{{version}}.tar.gz
-  sha256: ba793a2d41995d65ce4ee9e955e06342a6357174420b727cfde9fc6c70590e92
+  sha256: 88e834b27cb9c50fa09ce70cbb41d1c96586882e28c921d644287be73ae9c4a5
 
 build:
-  number: 6
+  number: 0
   skip: true  # [win]
 
 requirements:
@@ -90,7 +90,6 @@ test:
     - ffc.backends.ufc
     - ffc.errorcontrol
     - ffc.quadrature
-    - ffc.tensor
     - dolfin
 
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,8 @@
-{% set petsc_version = '3.7.*' %}
 {% set version = "2017.2.0" %}
+{% set petsc_version = '3.8.*' %}
 {% set swig_version = '3.0.12' %}
+{% set mpi = "mpich" %}
+{% set mpi_version = '3.2.*' %}
 
 package:
   name: fenics
@@ -20,15 +22,15 @@ requirements:
     - pip
     # Make sure libgcc 5.* is not used at build time
     - libgcc 4.8.*  # [linux]
-    - gcc  # [linux]
-    - boost 1.64.*
+    - gcc 4.8.*  # [linux]
+    - boost 1.65.1
     - cmake
-    - eigen
+    - eigen 3.3.*
     - pkg-config
-    - ptscotch
+    - ptscotch 6.0.4
     - toolchain
     - zlib 1.2.*
-    - mpich
+    - {{mpi}} {{mpi_version}}
     - petsc {{petsc_version}}
     - petsc4py {{petsc_version}}
     - slepc {{petsc_version}}
@@ -39,22 +41,22 @@ requirements:
     - six
     - subprocess32  # [py2k]
     - sympy
-    - hdf5 1.8.18
+    - hdf5 1.10.1
 
   run:
     - python
     - setuptools
-    - boost 1.64.*
+    - boost 1.65.1
     - cmake
-    - eigen
-    - gcc  # [linux]
-    - mpich
+    - eigen 3.3.*
+    - gcc 4.8.*  # [linux]
+    - {{mpi}} {{mpi_version}}
     - petsc {{petsc_version}}
     - petsc4py {{petsc_version}}
     - slepc {{petsc_version}}
     - slepc4py {{petsc_version}}
     - pkg-config
-    - ptscotch
+    - ptscotch 6.0.4
     - zlib 1.2.*
     - ply
     - swig {{swig_version}}
@@ -62,7 +64,7 @@ requirements:
     - six
     - subprocess32  # [py2k]
     - sympy
-    - hdf5 1.8.18
+    - hdf5 1.10.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - slepc {{petsc_version}}
     - slepc4py {{petsc_version}}
     - swig {{swig_version}}
-    - numpy 1.13.*
+    - numpy 1.13.* *openblas*
     - ply
     - six
     - subprocess32  # [py2k]
@@ -60,7 +60,7 @@ requirements:
     - zlib 1.2.*
     - ply
     - swig {{swig_version}}
-    - numpy 1.13.*
+    - numpy 1.13.* *openblas*
     - six
     - subprocess32  # [py2k]
     - sympy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@ package:
   version: {{version}}
 
 source:
-  url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-{{version}}.tar.gz
-  sha256: 88e834b27cb9c50fa09ce70cbb41d1c96586882e28c921d644287be73ae9c4a5
+  url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-{{version}}.post0.tar.gz
+  sha256: d3c40cd8c1c882f517999c25ea4220adcd01dbb1d829406fce99b1fc40184c82
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - libgcc 4.8.*  # [linux]
     - gcc 4.8.*  # [linux]
     - boost 1.65.1
-    - cmake
+    - cmake >=3.9
     - eigen 3.3.*
     - pkg-config
     - ptscotch 6.0.4
@@ -47,7 +47,7 @@ requirements:
     - python
     - setuptools
     - boost 1.65.1
-    - cmake
+    - cmake >=3.9
     - eigen 3.3.*
     - gcc 4.8.*  # [linux]
     - {{mpi}} {{mpi_version}}


### PR DESCRIPTION
updates several dependencies and pins (petsc 3.8, etc.)

This build for me (macOS, py36), we'll see if CI agrees.

@garth-wells any other changes to dependencies/tests/build configuration I should make?