### PR TITLE
pin pybind11 down to patch version at build time

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -25,6 +25,10 @@ pin_run_as_build:
     max_pin: x.x
   ptscotch:
     max_pin: x.x.x
+  # pybind11 generation breaks on patch releases
+  # at least between 2.2.3 and 2.2.4
+  pybind11:
+    max_pin: x.x.x
   slepc:
     max_pin: x.x
   slepc4py:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - public-eigenlubase.patch  # [osx]
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win or py2k]
   run_exports:
     - {{ pin_subpackage('fenics', 'max_pin=x.x.x') }}


### PR DESCRIPTION
pybind used for code generation must match exactly the version used at build time to avoid issues like:

    ImportError: generic_type: type "Conductivity" referenced unknown base type "dolfin::Expression"

It's unclear how true this is in general, but we at least know that when dolfin is built with 2.2.3, code generation fails with 2.2.4.