### PR TITLE
remove Python dependency from libdolfin

### DIFF
--- a/recipe/build-libdolfin.sh
+++ b/recipe/build-libdolfin.sh
@@ -42,7 +42,7 @@ cmake .. \
   -DCMAKE_INCLUDE_PATH=$INCLUDE_PATH \
   -DCMAKE_LIBRARY_PATH=$LIBRARY_PATH \
   -DUFC_INCLUDE_DIR=$UFC_INCLUDE_DIR \
-  -DPYTHON_EXECUTABLE=$PREFIX/bin/python || (cat CMakeFiles/CMakeError.log && exit 1)
+  -DPYTHON_EXECUTABLE=$BUILD_PREFIX/bin/python || (cat CMakeFiles/CMakeError.log && exit 1)
 
 make VERBOSE=1 -j${CPU_COUNT}
 make install

--- a/recipe/build-libdolfin.sh
+++ b/recipe/build-libdolfin.sh
@@ -14,6 +14,11 @@ fi
 export CFLAGS=$(echo $CFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
 export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
 
+# add ufc header from ffc sources
+UFC_INCLUDE_DIR=$PREFIX/include
+mkdir -p $UFC_INCLUDE_DIR
+cp ../ffc/ffc/backends/ufc/ufc.h $UFC_INCLUDE_DIR/ufc.h
+
 # DOLFIN
 
 rm -rf build
@@ -36,6 +41,7 @@ cmake .. \
   -DCMAKE_INSTALL_LIBDIR=$PREFIX/lib \
   -DCMAKE_INCLUDE_PATH=$INCLUDE_PATH \
   -DCMAKE_LIBRARY_PATH=$LIBRARY_PATH \
+  -DUFC_INCLUDE_DIR=$UFC_INCLUDE_DIR \
   -DPYTHON_EXECUTABLE=$PREFIX/bin/python || (cat CMakeFiles/CMakeError.log && exit 1)
 
 make VERBOSE=1 -j${CPU_COUNT}

--- a/recipe/build-libdolfin.sh
+++ b/recipe/build-libdolfin.sh
@@ -14,11 +14,6 @@ fi
 export CFLAGS=$(echo $CFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
 export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
 
-# add ufc header from ffc sources
-UFC_INCLUDE_DIR=$PREFIX/include
-mkdir -p $UFC_INCLUDE_DIR
-cp ../ffc/ffc/backends/ufc/ufc.h $UFC_INCLUDE_DIR/ufc.h
-
 # DOLFIN
 
 rm -rf build
@@ -41,8 +36,7 @@ cmake .. \
   -DCMAKE_INSTALL_LIBDIR=$PREFIX/lib \
   -DCMAKE_INCLUDE_PATH=$INCLUDE_PATH \
   -DCMAKE_LIBRARY_PATH=$LIBRARY_PATH \
-  -DUFC_INCLUDE_DIR=$UFC_INCLUDE_DIR \
-  -DPYTHON_EXECUTABLE=$BUILD_PREFIX/bin/python || (cat CMakeFiles/CMakeError.log && exit 1)
+  -DPYTHON_EXECUTABLE=$PREFIX/bin/python || (cat CMakeFiles/CMakeError.log && exit 1)
 
 make VERBOSE=1 -j${CPU_COUNT}
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
   - url: https://bitbucket.org/fenics-project/ffc/downloads/ffc-{{version}}.tar.gz
     sha256: 4ff821a234869d8b9aaf8c5d7f617d42f9c134a2529e76c9519b681dff35affd
     folder: ffc
+    patches:
+      - ufc-include-path.patch
   - url: https://bitbucket.org/fenics-project/fiat/downloads/fiat-{{version}}.tar.gz
     sha256: 341a1046cbe0f5f2eb26630c2f71f378b0dca51daf9892a54a2ff193970371e9
     folder: fiat
@@ -89,7 +91,10 @@ outputs:
   - name: fenics-ffc
     build:
       noarch: python
-      script: $PYTHON -m pip install --no-deps ./ffc
+      script:
+        - $PYTHON -m pip install --no-deps ./ffc
+        - mkdir -p $PREFIX/include
+        - cp ffc/ffc/backends/ufc/*.h $PREFIX/include/
       skip: true  # [win or py2k]
     requirements:
       host:
@@ -113,6 +118,8 @@ outputs:
         - ffc.quadrature
       commands:
         - ffc --help
+        - test -f $PREFIX/include/ufc.h
+        - test -f $PREFIX/include/ufc_geometry.h
 
   - name: fenics-libdolfin
     build:
@@ -122,7 +129,6 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - python >=3.5
       host:
         - boost-cpp
         - cmake >=3.9
@@ -136,6 +142,7 @@ outputs:
         - {{ mpi }}
         - petsc =={{ petsc }}
         - slepc =={{ petsc }}
+        - fenics-ffc =={{ version }}
       run:
         - {{ compiler('cxx') }}  # [linux]
         - boost-cpp
@@ -150,6 +157,7 @@ outputs:
         - ptscotch
         - suitesparse
         - zlib
+        - fenics-ffc =={{ version }}
       run_constrained:
         - fenics =={{ version }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,6 +122,7 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - python >=3.5
       host:
         - boost-cpp
         - cmake >=3.9
@@ -135,7 +136,6 @@ outputs:
         - {{ mpi }}
         - petsc =={{ petsc }}
         - slepc =={{ petsc }}
-        - fenics-ffc =={{ version }}
       run:
         - {{ compiler('cxx') }}  # [linux]
         - boost-cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: dolfin
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or py2k]
 
 outputs:
@@ -135,9 +135,6 @@ outputs:
         - {{ mpi }}
         - petsc =={{ petsc }}
         - slepc =={{ petsc }}
-        # FIXME: libdolfin shouldn't require Python
-        # but its cmake files do
-        - python
         - fenics-ffc =={{ version }}
       run:
         - {{ compiler('cxx') }}  # [linux]
@@ -153,9 +150,6 @@ outputs:
         - ptscotch
         - suitesparse
         - zlib
-        # FIXME: remove Python dependency
-        - python
-        - fenics-ffc =={{ version }}
       run_constrained:
         - fenics =={{ version }}
     test:

--- a/recipe/ufc-include-path.patch
+++ b/recipe/ufc-include-path.patch
@@ -1,0 +1,17 @@
+Description: Use $PREFIX/include as include path for ufc
+ Upstream is not interested in switching to this path.
+Forwarded: not-needed
+Author: Min RK <benjaminrk@simula.no>, Johannes Ring <johannr@simula.no>
+Last-Update: 2019-05-02
+
+--- ffc-2019.1.0.orig/ffc/backends/ufc/__init__.py
++++ ffc-2019.1.0/ffc/backends/ufc/__init__.py
+@@ -62,6 +62,8 @@ from ffc.backends.ufc.form import *
+ # Get abspath on import, it can in some cases be
+ # a relative path w.r.t. curdir on startup
+ _include_path = os.path.dirname(os.path.abspath(__file__))
++import sys
++_include_path = sys.prefix + "/include"
+ 
+ def get_include_path():
+     "Return location of UFC header files"


### PR DESCRIPTION
<del>by setting -DUFC_INCLUDE_DIR and copying ufc.h out of ffc into $PREFIX/include</del>

by copying debian:

- copy ufc*.h to $PREFIX/include
- patch ufc includ_dir to $PREFIX/include