### PR TITLE
add runtime requirement on blas-devel

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
       - linuxboost.patch  # [linux]
 
 build:
-  number: 18
+  number: 19
   skip: true  # [win]
 
 # NOTE: Top-level environment with boost-cpp is only to separate the build for
@@ -158,6 +158,7 @@ outputs:
         - hdf5 * {{ mpi_prefix }}_*
       run:
         - {{ compiler('cxx') }}  # [linux]
+        - blas-devel
         - cmake >=3.9
         - eigen
         - {{ mpi }}
@@ -213,6 +214,7 @@ outputs:
         - hdf5 * {{ mpi_prefix }}_*
       run:
         - {{ compiler('cxx') }}  # [linux]
+        - blas-devel
         - python
         - boost-cpp
         - setuptools


### PR DESCRIPTION
libblas.so and friends are moving to a metapackage, and petsc config assumes these canonical names

cf https://github.com/conda-forge/petsc-feedstock/pull/106
cf https://github.com/conda-forge/blas-feedstock/issues/29