### PR TITLE
strip libdolfin

### DIFF
--- a/recipe/build-libdolfin.sh
+++ b/recipe/build-libdolfin.sh
@@ -54,4 +54,9 @@ if [[ "$(uname)" == "Darwin" ]]; then
     find $PREFIX/share/dolfin -name '*.cmake' -print -exec sh -c "sed -E -i ''  's@/Applications/Xcode.app[^;]*(.dylib|.framework|.a);@@g' {}" \;
 else
     find $PREFIX/share/dolfin -name '*.cmake' -print -exec sh -c "sed -E -i''  's@/usr/lib(64)?/[^;]*(.so|.a);@@g' {}" \;
+
+    # strip libdolfin
+    # it's unclear why this doesn't happen from the default flags
+    # it seems to on mac
+    strip -s $PREFIX/lib/libdolfin.so
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
       - find-petsc-slepc.patch
 
 build:
-  number: 19
+  number: 20
   skip: true  # [win]
 
 # NOTE: Top-level environment with boost-cpp is only to separate the build for


### PR DESCRIPTION
shrinks from ~150MB installed to ~6MB

It seems like this is supposed to happen by default on conda-forge, but doesn't on libdolfin.