### PR TITLE
ensure all mpi builds of metapackage are uploaded

### DIFF
--- a/.ci_support/linux_64_mpimpichnumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.20python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/linux_64_mpimpichnumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.20python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/linux_64_mpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/linux_64_mpimpichnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.23python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.20python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.20python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.20python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 hdf5:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.20python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 hdf5:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 hdf5:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.23python3.11.____cpython.yaml
@@ -5,7 +5,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 hdf5:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.20python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 hdf5:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.20python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 hdf5:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 hdf5:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -5,7 +5,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 hdf5:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.20python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 hdf5:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.20python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 hdf5:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 hdf5:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.23python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 hdf5:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.20python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 hdf5:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.20python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 hdf5:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 hdf5:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 hdf5:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About fenics-pkgs
 
 Home: http://www.fenicsproject.org
 
-Package license: LGPL 3.0
+Package license: LGPL-3.0-or-later
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/fenics-feedstock/blob/main/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,8 +56,6 @@ outputs:
         - python
         - numpy
         - setuptools
-      run_constrained:
-        - fenics =={{ version }}
     test:
       imports:
         - dijitso
@@ -74,8 +72,6 @@ outputs:
         - setuptools
         - numpy
         - sympy >=1
-      run_constrained:
-        - fenics =={{ version }}
     test:
       imports:
         - FIAT
@@ -91,8 +87,6 @@ outputs:
         - python
         - setuptools
         - numpy
-      run_constrained:
-        - fenics =={{ version }}
     test:
       imports:
         - ufl
@@ -118,8 +112,6 @@ outputs:
         - {{ pin_subpackage("fenics-dijitso", exact=True) }}
         - {{ pin_subpackage("fenics-fiat", exact=True) }}
         - {{ pin_subpackage("fenics-ufl", exact=True) }}
-      run_constrained:
-        - fenics =={{ version }}
     test:
       imports:
         - ffc
@@ -180,8 +172,6 @@ outputs:
         - zlib
         - fenics-ffc =={{ version }}
         - boost-cpp
-      run_constrained:
-        - fenics =={{ version }}
     test:
       commands:
         - test -f ${PREFIX}/lib/libdolfin${SHLIB_EXT}
@@ -246,8 +236,6 @@ outputs:
         - fenics-fiat =={{ version }}
         - fenics-ufl =={{ version }}
         - fenics-ffc =={{ version }}
-      run_constrained:
-        - fenics =={{ version }}
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
       - fix-xdmf.patch
 
 build:
-  number: 34
+  number: 35
   skip: true  # [win]
 
 # NOTE: Top-level environment with boost-cpp is only to separate the build for
@@ -256,6 +256,7 @@ outputs:
     requirements:
       host:
         - python
+        - {{ mpi }}  # ensure mpi is in hash inputs
       run:
         - python
         - {{ pin_subpackage("fenics-dijitso", exact=True) }}


### PR DESCRIPTION
closes #170 

this doesn't solve the problem _in general_ because we'll need every dependency _for which we have multiple variants_ included here, but it should be enough for now.

I took the opportunity to remove the `run_constrained` requirement from the components, which make a circular restriction. This is based on discussions around a possible new release of legacy fenics, and these prevent making a release of a _partial_ package, where `dolfin 2023.1` might depend on the existing `dijitso 2019.1`, without needing a coordinated release of everything.