### PR TITLE
scotch doesn't seem to work on mac-arm

### DIFF
--- a/recipe/build-libdolfin.sh
+++ b/recipe/build-libdolfin.sh
@@ -20,6 +20,13 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" != "0" ]]; then
   export CMAKE_ARGS="${CMAKE_ARGS} -DDOLFIN_SKIP_BUILD_TESTS=ON"
 fi
 
+if [[ "${target_platform}" == "osx-arm64" ]]; then
+  # scotch seems to crash on osx-arm64
+  export CMAKE_ARGS="${CMAKE_ARGS} -DDOLFIN_ENABLE_SCOTCH=OFF"
+else
+  export CMAKE_ARGS="${CMAKE_ARGS} -DDOLFIN_ENABLE_SCOTCH=ON"
+fi
+
 # dolfinx pkg-config records compilers
 # avoid recording build prefix
 export CC=$(basename $CC)
@@ -41,7 +48,6 @@ cmake .. \
   -DDOLFIN_ENABLE_MPI=on \
   -DDOLFIN_ENABLE_PETSC=on \
   -DDOLFIN_ENABLE_SLEPC=on \
-  -DDOLFIN_ENABLE_SCOTCH=on \
   -DDOLFIN_ENABLE_HDF5=on \
   -DPYTHON_EXECUTABLE=$PREFIX/bin/python || (cat CMakeFiles/CMakeError.log && exit 1)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - python-cmake-args.patch
 
 build:
-  number: 45
+  number: 46
   skip: true  # [win]
   # this doesn't actually affect the build hashes
   # so duplicate where the build hash should actually change
@@ -59,7 +59,7 @@ outputs:
         - libboost-devel
         - eigen
         - parmetis
-        - libptscotch
+        - libptscotch  # [target_platform != "osx-arm64"]
         - suitesparse
         - zlib
         - {{ mpi }}


### PR DESCRIPTION
unclear if scotch or dolfin is responsible, but seems to work with boost/parmetis

tested the osx-arm64 builds and they consistently crash when calling scotch in either dof_reordering or mesh partitioning. But setting:

```python
parameters['mesh_partitioner'] = 'ParMETIS'
parameters['dof_ordering_library'] = 'Boost'
```

makes things work reliably, so I imagine omitting scotch will get things working by default.

Unclear if this is dolfin's fault or scotch's, but since this is legacy dolfin on a new platform where we still can't run tests, start by omitting the optional dependency that doesn't seem to work.

