### PR TITLE
Depend on gxx

### DIFF
--- a/recipe/build-dolfin.sh
+++ b/recipe/build-dolfin.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eux
 
-cd dolfin
-
 # scrub problematic -fdebug-prefix-map from C[XX]FLAGS
 # these are loaded in the clang[++] activate scripts
 export CFLAGS=$(echo $CFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')

--- a/recipe/build-libdolfin.sh
+++ b/recipe/build-libdolfin.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -eux
 
-unset CMAKE_PREFIX_PATH
-
-cd dolfin
-
 # scrub problematic -fdebug-prefix-map from C[XX]FLAGS
 # these are loaded in the clang[++] activate scripts
 export CFLAGS=$(echo $CFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,6 @@ package:
 source:
   - url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-{{ version }}.post0.tar.gz
     sha256: 61abdcdb13684ba2a3ba4afb7ea6c7907aa0896a46439d3af7e8848483d4392f
-    folder: dolfin
     patches:
       - boost.patch
       - linuxboost.patch  # [linux]
@@ -151,7 +150,7 @@ outputs:
       commands:
         - bash ${RECIPE_DIR}/parent/test-dolfin.sh
       source_files:
-        - dolfin/python/test
+        - python/test
 
       requires:
         - nose
@@ -180,9 +179,10 @@ outputs:
 about:
   home: http://www.fenicsproject.org
   license: LGPL-3.0-or-later
+  license_family: LGPL
   license_file:
-    - dolfin/COPYING
-    - dolfin/COPYING.LESSER
+    - COPYING
+    - COPYING.LESSER
   summary: 'FEniCS is a collection of free software for automated, efficient solution of differential equations'
 
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - python-cmake-args.patch
 
 build:
-  number: 47
+  number: 48
   skip: true  # [win]
   # this doesn't actually affect the build hashes
   # so duplicate where the build hash should actually change
@@ -127,6 +127,8 @@ outputs:
         - hdf5 * {{ mpi_prefix }}_*
       run:
         - {{ compiler('cxx') }}
+        # gxx provides default 'c++' executable on linux
+        - gxx  # [linux]
         - python
         # dolfin depends on the boost headers for its own headers, see
         # https://bitbucket.org/fenics-project/dolfin/src/master/dolfin/parameter/Parameters.h#lines-24

--- a/recipe/test-dolfin.sh
+++ b/recipe/test-dolfin.sh
@@ -31,7 +31,7 @@ EOF
 
 python -c 'from dolfin import *; info(parameters["form_compiler"], True)'
 
-pushd "dolfin/python/test/unit"
+pushd "python/test/unit"
 TESTS="jit fem/test_form.py::test_assemble_linear"
 
 RUN_TESTS="python -b -m pytest -vs $TESTS"


### PR DESCRIPTION
gxx provides `gxx` `c++` executables, which should be found as long as the env is on $PATH, even when env isn't activated to set $CXX.

closes #204 