### PR TITLE
fix and test pip check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,10 @@ source:
       - python-cmake-args.patch
       - boost-1.86.patch
       - numpy-2.0.patch
+      - unpin-pybind.patch
 
 build:
-  number: 54
+  number: 55
   skip: true  # [win]
   # this doesn't actually affect the build hashes
   # so duplicate where the build hash should actually change
@@ -146,11 +147,13 @@ outputs:
 
     test:
       commands:
+        - pip check
         - bash ${RECIPE_DIR}/parent/test-dolfin.sh
       source_files:
         - python/test
 
       requires:
+        - pip
         - nose
         - pytest
         - git

--- a/recipe/unpin-pybind.patch
+++ b/recipe/unpin-pybind.patch
@@ -1,0 +1,26 @@
+From e09898e05c7ec2a8260bb5182a587ebe9cf99007 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Thu, 20 Feb 2025 08:57:28 +0100
+Subject: [PATCH] unpin pybind
+
+pin not actually needed
+---
+ python/setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/python/setup.py b/python/setup.py
+index d4aa8d38e..4323ae4ab 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -18,7 +18,7 @@ RESTRICT_REQUIREMENTS = ">=2019.1.0,<2019.2"
+ 
+ REQUIREMENTS = ["numpy",
+                 "pkgconfig",
+-                "pybind11==2.2.4",
++                "pybind11",
+                 "fenics-ffc{}".format(RESTRICT_REQUIREMENTS),
+                 "fenics-ufl{}".format(RESTRICT_REQUIREMENTS),
+                 "fenics-dijitso{}".format(RESTRICT_REQUIREMENTS)]
+-- 
+2.47.0
+


### PR DESCRIPTION
unpins pybind in 2019.1 ([same already done upstream](https://bitbucket.org/fenics-project/dolfin/commits/409edb78212b9771cf5cd6d38a568efec0013f04#Lpython/setup.pyF22))

the actual pinning that's required (runtime is the same as build-time) is handled by `pin_run_as_build`